### PR TITLE
Respect indentation in doc comments.

### DIFF
--- a/src/ParsedFile.js
+++ b/src/ParsedFile.js
@@ -52,7 +52,7 @@ export default class ParsedFile {
       })
       .map(function(comment) {
         return {
-          value: comment.value.slice(1).replace(/^ *\*+ */gm, ''), // remove extra spaces and '*'
+          value: comment.value.slice(1).replace(/^ *\*+ ?/gm, ''), // remove extra spaces and '*'
           location: comment.loc,
         };
       })


### PR DESCRIPTION
@anatoo I noticed that `wcdoc` removes all leading whitespaces from the comments.

```
/**
 * @example
 * <ons-carousel style="width: 100%; height: 200px">
 *   <ons-carousel-item>
 *    ...
 *   </ons-carousel-item>
 *   <ons-carousel-item>
 *    ...
 *   </ons-carousel-item>
 * </ons-carousel>
 */
```

was converted to

```
@example
<ons-carousel style="width: 100%; height: 200px">
<ons-carousel-item>
...
</ons-carousel-item>
<ons-carousel-item>
...
</ons-carousel-item>
</ons-carousel>
```

so we lose the indenation. This PR fixes the issue.
