### PR TITLE
Change from esprima to espree parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-cli": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
-    "esprima": "^2.7.1",
+    "espree": "^3.3.2",
     "estraverse": "^4.1.1",
     "globby": "^4.0.0",
     "typescript": "^1.8.10"

--- a/src/ParsedFile.js
+++ b/src/ParsedFile.js
@@ -1,6 +1,6 @@
 import globby from 'globby';
 import fs from 'fs';
-import esprima from 'esprima';
+import espree from 'espree';
 import estraverse from 'estraverse';
 import TagDict from './TagDict';
 import {relative, resolve} from 'path';
@@ -75,13 +75,17 @@ export default class ParsedFile {
   }
 
   static _parseJS(code, options = {}) {
-    const ast = esprima.parse(code, {
+    const ast = espree.parse(code, {
       loc: true,
       range: true,
       raw: false,
       tokens: true,
       comment: true,
-      tolerant: true
+      tolerant: true,
+      ecmaVersion: 7,
+      ecmaFeatures: {
+        experimentalObjectRestSpread: true
+      }
     });
 
     const docComments = ParsedFile._buildDocComments(ast);


### PR DESCRIPTION
@anatoo I changed from using esprima to espree since it supports newer features such as object rest spread.
